### PR TITLE
Fix date range calculation in weather API

### DIFF
--- a/weather_api.py
+++ b/weather_api.py
@@ -31,7 +31,7 @@ def get_num_days(start, end):
     start_date = datetime.strptime(start, '%Y-%m-%d')
     end_date = datetime.strptime(end, '%Y-%m-%d')
     delta = end_date - start_date
-    return delta.days
+    return delta.days + 1
 
 
 def get_num_obs(start, end, aggregator):


### PR DESCRIPTION
## Summary
- fix weather_api `get_num_days` to include both start and end date

## Testing
- `python -m py_compile weather_api.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_b_6847305fe5b083269d0ad73911511cef